### PR TITLE
Adjust dependency range for org.eventb.emf.core to [5.0.0,6.0.0)

### DIFF
--- a/ac.soton.eventb.emf.core.extension.edit/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.core.extension.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ac.soton.eventb.emf.core.extension.edit;singleton:=true
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: ac.soton.eventb.emf.core.extension.coreextension.provider.EventbcoreextensionEditPlugin$Implementation
 Bundle-Vendor: %providerName
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.emf.edit;bundle-version="[2.7.0,3.0.0)",
  org.eclipse.emf.ecore;bundle-version="[2.7.0,3.0.0)",
  org.eclipse.emf.ecore.edit;bundle-version="[2.7.0,3.0.0)",
- org.eventb.emf.core;bundle-version="[4.0.0,5.0.0)",
+ org.eventb.emf.core;bundle-version="[5.0.0,6.0.0)",
  org.eventb.emf.core.edit;bundle-version="[1.0.0,2.0.0)",
  ac.soton.eventb.emf.core.extension;bundle-version="[4.0.0,5.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/ac.soton.eventb.emf.core.extension.feature/feature.properties
+++ b/ac.soton.eventb.emf.core.extension.feature/feature.properties
@@ -22,6 +22,11 @@ featureDescription=\
 Generic features to support developers making extensions to the EventB EMF Framework.\n\
 -------------------------------------------------------------------------------------\n\
 Release history:\n\
+5.4.1\n\
+  extension (4.0.1) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0)\n\
+  edit (1.0.1) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0)\n\
+  navigator (4.4.1) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0)\n\
+  persistence (2.1.3) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0)\n\
 5.4.0\n\
  navigator (4.4.0) - improvements to element refiner - more robust for intra component refs,\n\
  			allow emf models to be displayed in navigator\n\

--- a/ac.soton.eventb.emf.core.extension.feature/feature.xml
+++ b/ac.soton.eventb.emf.core.extension.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.core.extension.feature"
       label="%featureName"
-      version="5.4.0.release"
+      version="5.4.1.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.license"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.emf.core.extension.navigator/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.core.extension.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.eventb.emf.core.extension.navigator;singleton:=true
-Bundle-Version: 4.4.0.release
+Bundle-Version: 4.4.1.qualifier
 Bundle-Activator: ac.soton.eventb.emf.core.extension.navigator.ExtensionNavigatorPlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",
  org.rodinp.core;bundle-version="[1.7.0,2.0.0)",
  org.eventb.core;bundle-version="[3.0.0,4.0.0)",
  fr.systerel.explorer;bundle-version="[2.0.0,3.0.0)",
- org.eventb.emf.core;bundle-version="[4.2.0,5.0.0)",
+ org.eventb.emf.core;bundle-version="[5.0.0,6.0.0)",
  org.eventb.emf.core.edit;bundle-version="[1.0.0,2.0.0)",
  org.eventb.emf.persistence;bundle-version="[3.4.0,4.0.0)",
  ac.soton.eventb.emf.core.extension;bundle-version="[4.0.0,5.0.0)",

--- a/ac.soton.eventb.emf.core.extension.persistence/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.core.extension.persistence/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.eventb.emf.core.extension.persistence;singleton:=true
-Bundle-Version: 2.1.2
+Bundle-Version: 2.1.3.qualifier
 Bundle-Activator: ac.soton.eventb.emf.core.extension.persistence.ExtensionPersistencePlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.emf.ecore.xmi;bundle-version="[2.7.0,3.0.0)",
  org.rodinp.core;bundle-version="[1.7.0,2.0.0)",
  org.eventb.core;bundle-version="[3.0.0,4.0.0)",
- org.eventb.emf.core;bundle-version="[4.2.0,5.0.0)",
+ org.eventb.emf.core;bundle-version="[5.0.0,6.0.0)",
  org.eventb.emf.persistence;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.emf.transaction;bundle-version="[1.4.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/ac.soton.eventb.emf.core.extension/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.core.extension/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ac.soton.eventb.emf.core.extension;singleton:=true
-Bundle-Version: 4.0.0
+Bundle-Version: 4.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -12,5 +12,5 @@ Export-Package: ac.soton.eventb.emf.core.extension.coreextension,
  ac.soton.eventb.emf.core.extension.coreextension.util
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.emf.ecore;bundle-version="[2.7.0,3.0.0)",
- org.eventb.emf.core;bundle-version="[4.0.0,5.0.0)"
+ org.eventb.emf.core;bundle-version="[5.0.0,6.0.0)"
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
The only change is to adjust the dependency range to work with the new major version of org.eventb.emf.core. These plugins are not affected by the API change, so work fine with the new version.