### PR TITLE
when making a refined extension give it a new extension id 

### DIFF
--- a/ac.soton.eventb.emf.core.extension.feature/feature.properties
+++ b/ac.soton.eventb.emf.core.extension.feature/feature.properties
@@ -26,7 +26,8 @@ Release history:\n\
 ### 5.4.1 ### \n\
   extension (4.0.1) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0)\n\
   edit (1.0.1) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0)\n\
-  navigator (4.4.1) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0)\n\
+  navigator (4.5.0) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0),\n\
+  						when refining extensions give the new extension a new id\n\
   persistence (2.1.3) - adjust dependency for org.eventb.emf.core [5.0.0,6.0.0)\n\
 ### 5.4.0 ### \n\
  navigator (4.4.0) - improvements to element refiner - more robust for intra component refs,\n\

--- a/ac.soton.eventb.emf.core.extension.feature/feature.xml
+++ b/ac.soton.eventb.emf.core.extension.feature/feature.xml
@@ -22,7 +22,6 @@
    <requires>
       <import plugin="org.eclipse.core.runtime" version="3.7.0" match="compatible"/>
       <import plugin="org.eclipse.emf.ecore" version="2.7.0" match="compatible"/>
-      <import plugin="org.eventb.emf.core" version="4.0.0" match="compatible"/>
       <import plugin="org.eclipse.ui" version="3.7.0" match="compatible"/>
       <import plugin="org.eclipse.core.expressions" version="3.4.300" match="compatible"/>
       <import plugin="org.eclipse.ui.navigator" version="3.5.100" match="compatible"/>
@@ -32,7 +31,6 @@
       <import plugin="org.rodinp.core" version="1.7.0" match="compatible"/>
       <import plugin="org.eventb.core" version="3.0.0" match="compatible"/>
       <import plugin="fr.systerel.explorer" version="2.0.0" match="compatible"/>
-      <import plugin="org.eventb.emf.core" version="4.2.0" match="compatible"/>
       <import plugin="org.eventb.emf.core.edit" version="1.0.0" match="compatible"/>
       <import plugin="org.eventb.emf.persistence" version="3.4.0" match="compatible"/>
       <import plugin="ac.soton.eventb.emf.core.extension" version="4.0.0" match="compatible"/>
@@ -41,6 +39,7 @@
       <import plugin="org.eventb.emf.persistence" version="3.3.0" match="compatible"/>
       <import plugin="org.eclipse.emf.transaction" version="1.4.0" match="compatible"/>
       <import plugin="org.eclipse.emf.edit" version="2.7.0" match="compatible"/>
+      <import plugin="org.eventb.emf.core" version="5.0.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/ac.soton.eventb.emf.core.extension.navigator/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.core.extension.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.eventb.emf.core.extension.navigator;singleton:=true
-Bundle-Version: 4.4.1.qualifier
+Bundle-Version: 4.5.0.qualifier
 Bundle-Activator: ac.soton.eventb.emf.core.extension.navigator.ExtensionNavigatorPlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",

--- a/ac.soton.eventb.emf.core.extension.navigator/src/ac/soton/eventb/emf/core/extension/navigator/refiner/AbstractExtensionRefiner.java
+++ b/ac.soton.eventb.emf.core.extension.navigator/src/ac/soton/eventb/emf/core/extension/navigator/refiner/AbstractExtensionRefiner.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.EcoreUtil.Copier;
 import org.eventb.core.IEventBRoot;
+import org.eventb.emf.core.AbstractExtension;
 import org.eventb.emf.core.CorePackage;
 import org.eventb.emf.core.EventBElement;
 import org.eventb.emf.core.EventBObject;
@@ -213,8 +214,11 @@ public abstract class AbstractExtensionRefiner implements IRefinementParticipant
 	private void refineExtension(IEventBRoot concreteEventBRoot, IEventBRoot abstractEventBRoot, ISerialisedExtension abstractExtensionRoot, IProgressMonitor monitor) throws RodinDBException, CoreException 	{		
 		//obtain the EMF version of the abstract serialised extension by loading it into a Rodin Resource
 		EventBObject extension = emfRodinDB.loadElement(abstractExtensionRoot);
+		//refine extension and give it a new id (using uuid)
+		EventBElement refinedExtension = refineEventBElement(extension);
+		((AbstractExtension)refinedExtension).setExtensionId(EXTENSION_ID+"."+EcoreUtil.generateUUID());
 		//serialise refined extension back into the RodinDB concreteEventBRoot (not into EMF resource as this does not exist yet)
-		synchroniser.save(refineEventBElement(extension), concreteEventBRoot, monitor);
+		synchroniser.save(refinedExtension, concreteEventBRoot, monitor);
 	}
 
 	


### PR DESCRIPTION
The refinement participant used to copy the abstract model (e.g. state-machine) without changing the extension id. 
This causes problems when re-generating because the translator removes all generated elements annotated with the models extension id. Having a new extension id will make it clearer to distinguish between abstract and refined models.
(A refinement participant will be needed to regenerate - this is done elsewhere)