### PR TITLE
do not set rodin extensionId if emf extensionId is null

### DIFF
--- a/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/SerialisedExtensionSynchroniser.java
+++ b/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/SerialisedExtensionSynchroniser.java
@@ -167,7 +167,9 @@ public class SerialisedExtensionSynchroniser extends AbstractSynchroniser {
 			
 			try {
 				String saveString = XMIHelperImpl.saveString(Collections.emptyMap(), Collections.singletonList(emfExtension), "UTF-8", null);
-				rodinExtension.setExtensionId(emfExtension.getExtensionId(), monitor);
+				if (emfExtension.getExtensionId()!=null) {
+					rodinExtension.setExtensionId(emfExtension.getExtensionId(), monitor);
+				}
 				rodinExtension.setSerialised(saveString, monitor);
 				rodinExtension.setEPackageURI(emfExtension.eClass().getEPackage().getNsURI(), monitor);
 				rodinExtension.setEClassifier(emfExtension.eClass().getName(), monitor);


### PR DESCRIPTION
extensionId is now non-required.

@dd4g12 - please check this works for your inclusion use case.