### PR TITLE
Fix problems with serialisation of extensions

### DIFF
--- a/ac.soton.eventb.emf.core.extension.feature/feature.properties
+++ b/ac.soton.eventb.emf.core.extension.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011-2018 University of Southampton
+# Copyright (c) 2011-2019 University of Southampton
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,9 @@ Generic features to support developers making extensions to the EventB EMF Frame
 \n\
 Release history:\n\
 -------------------------------------------------------------------------------------\n\
+### 6.1.0 ### \n\
+  persistence (2.3.0) 	- save extensions serialised in Rodin using encoded attribute option\n\
+  						- provide a special XMI resource that always saves non-Rodin extensions with encoded attribute option\n\
 ### 6.0.0 ### \n\
   extension (5.0.0) 	- add refines for event group, removed copyright fields\n\
   						- update execution environment to java 1.8\n\
@@ -124,7 +127,7 @@ Release history:\n\
 		initial release\n\
 
 # "copyright" property - copyright of the feature
-featureCopyright=Copyright (c) 2011-2018 University of Southampton. All rights reserved.
+featureCopyright=Copyright (c) 2011-2019 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - label for the update site
 updateSiteName = Main Rodin update site

--- a/ac.soton.eventb.emf.core.extension.feature/feature.xml
+++ b/ac.soton.eventb.emf.core.extension.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.core.extension.feature"
       label="%featureName"
-      version="6.0.0.release"
+      version="6.1.0.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.license"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.emf.core.extension.persistence/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.core.extension.persistence/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.eventb.emf.core.extension.persistence;singleton:=true
-Bundle-Version: 2.2.0.release
+Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: ac.soton.eventb.emf.core.extension.persistence.ExtensionPersistencePlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",

--- a/ac.soton.eventb.emf.core.extension.persistence/plugin.xml
+++ b/ac.soton.eventb.emf.core.extension.persistence/plugin.xml
@@ -57,7 +57,7 @@
    </extension>
 
 
-	<!-- for persisting extensions as separate xmi files (force xmi to be used, xml does not work) -->
+	<!-- for persisting extensions as separate xmi files (use encoded attribute style for references) -->
    <extension
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type

--- a/ac.soton.eventb.emf.core.extension.persistence/plugin.xml
+++ b/ac.soton.eventb.emf.core.extension.persistence/plugin.xml
@@ -56,4 +56,23 @@
       </relationship>
    </extension>
 
+
+	<!-- for persisting extensions as separate xmi files (force xmi to be used, xml does not work) -->
+   <extension
+         point="org.eclipse.core.contenttype.contentTypes">
+      <content-type
+            base-type="org.eclipse.emf.ecore.xmi"
+            id="ac.soton.eventb.emf.core.extension.persistence.contentType"
+            name="EventB Extensions"
+            priority="normal">
+      </content-type>
+   </extension>
+   <extension
+         point="org.eclipse.emf.ecore.content_parser">
+      <parser
+ 			class="ac.soton.eventb.emf.core.extension.persistence.EventBExtensionResourceFactory"
+            contentTypeIdentifier="ac.soton.eventb.emf.core.extension.persistence.contentType">
+      </parser>
+   </extension>
+   
 </plugin>

--- a/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/EventBExtensionResource.java
+++ b/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/EventBExtensionResource.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
 
 /**
@@ -38,7 +37,7 @@ public class EventBExtensionResource extends XMIResourceImpl {
 	@Override
 	public void save(Map<?, ?> options) throws IOException {
 		Map options_encoded_attributes = new HashMap( options);
-		options_encoded_attributes.put(XMLResource.OPTION_USE_ENCODED_ATTRIBUTE_STYLE, Boolean.TRUE);
+		options_encoded_attributes.put(XMIResourceImpl.OPTION_USE_ENCODED_ATTRIBUTE_STYLE, Boolean.TRUE);
 		super.save(options_encoded_attributes);
 	}
 

--- a/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/EventBExtensionResource.java
+++ b/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/EventBExtensionResource.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2019 University of Southampton.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package ac.soton.eventb.emf.core.extension.persistence;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.xmi.XMLResource;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
+
+/**
+ * This resource forces the encoded attribute style to be used for extensions that are persisted as XMI 
+ * (i.e. separate from Rodin).
+ * 
+ * This style is needed because our reference id's contain semicolons ':' which are misinterpreted
+ * by the parser unless there is a resource part to the reference. 
+ * If there is a resource part the remainder after the delimiter (#) is interpreted correctly as an id.
+ * (i.e. at least a # character must be prefixed for the XMLHandler to parse the reference correctly)
+ * The Encoded attribute style always includes a resource part even if it is empty (i.e. the local file)
+ * resulting in a single # as a prefix. 
+ * 
+ * @since 2.3
+ */
+public class EventBExtensionResource extends XMIResourceImpl {
+
+	public EventBExtensionResource(URI uri) {
+		super(uri);
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	@Override
+	public void save(Map<?, ?> options) throws IOException {
+		Map options_encoded_attributes = new HashMap( options);
+		options_encoded_attributes.put(XMLResource.OPTION_USE_ENCODED_ATTRIBUTE_STYLE, Boolean.TRUE);
+		super.save(options_encoded_attributes);
+	}
+
+}

--- a/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/EventBExtensionResourceFactory.java
+++ b/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/EventBExtensionResourceFactory.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2019 University of Southampton.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package ac.soton.eventb.emf.core.extension.persistence;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+
+/**
+ * @author cfs
+ * @since 2.3
+ *
+ */
+public class EventBExtensionResourceFactory extends XMIResourceFactoryImpl{
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.emf.ecore.resource.Resource.Factory#createResource(org.eclipse.emf.common.util.URI)
+	 */
+	@Override
+	public Resource createResource(final URI uri) {
+		
+		return new EventBExtensionResource(uri);
+		
+	}
+
+}

--- a/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/SerialisedExtensionSynchroniser.java
+++ b/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/SerialisedExtensionSynchroniser.java
@@ -31,9 +31,9 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.URIConverter.ReadableInputStream;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.impl.XMIHelperImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
 import org.eventb.emf.core.AbstractExtension;
 import org.eventb.emf.core.CorePackage;
 import org.eventb.emf.core.EventBElement;
@@ -171,7 +171,7 @@ public class SerialisedExtensionSynchroniser extends AbstractSynchroniser {
 			
 			try {
 				Map<Object, Object> options_encoded_attributes = new HashMap<Object, Object>();
-				options_encoded_attributes.put(XMLResource.OPTION_USE_ENCODED_ATTRIBUTE_STYLE, Boolean.TRUE);
+				options_encoded_attributes.put(XMIResourceImpl.OPTION_USE_ENCODED_ATTRIBUTE_STYLE, Boolean.TRUE);
 				String saveString = XMIHelperImpl.saveString(options_encoded_attributes, Collections.singletonList(emfExtension), "UTF-8", null);
 				if (emfExtension.getExtensionId()!=null) {
 					rodinExtension.setExtensionId(emfExtension.getExtensionId(), monitor);

--- a/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/SerialisedExtensionSynchroniser.java
+++ b/ac.soton.eventb.emf.core.extension.persistence/src/ac/soton/eventb/emf/core/extension/persistence/SerialisedExtensionSynchroniser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 University of Southampton.
+ * Copyright (c) 2011-2019 University of Southampton.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,9 @@ package ac.soton.eventb.emf.core.extension.persistence;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
@@ -29,6 +31,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.URIConverter.ReadableInputStream;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.impl.XMIHelperImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.eventb.emf.core.AbstractExtension;
@@ -49,6 +52,7 @@ import org.rodinp.core.RodinDBException;
  * 
  * cfs (04/01/12) : when adding unique id's disable notification of changes (eventBElement.eSetDeliver(false)) to
  * 					prevent exceptions due to the change being made without a Transactional Command
+ * cfs (07/03/19) : use encoded attribute style for references
  * 
  * @author vitaly
  *
@@ -166,7 +170,9 @@ public class SerialisedExtensionSynchroniser extends AbstractSynchroniser {
 			AbstractExtension emfExtension = (AbstractExtension) emfElement;
 			
 			try {
-				String saveString = XMIHelperImpl.saveString(Collections.emptyMap(), Collections.singletonList(emfExtension), "UTF-8", null);
+				Map<Object, Object> options_encoded_attributes = new HashMap<Object, Object>();
+				options_encoded_attributes.put(XMLResource.OPTION_USE_ENCODED_ATTRIBUTE_STYLE, Boolean.TRUE);
+				String saveString = XMIHelperImpl.saveString(options_encoded_attributes, Collections.singletonList(emfExtension), "UTF-8", null);
 				if (emfExtension.getExtensionId()!=null) {
 					rodinExtension.setExtensionId(emfExtension.getExtensionId(), monitor);
 				}

--- a/ac.soton.eventb.emf.core.extension.sdk/feature.properties
+++ b/ac.soton.eventb.emf.core.extension.sdk/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011,2018 University of Southampton.
+# Copyright (c) 2011-2019 University of Southampton.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,6 +25,9 @@ Event-B EMF framework. \n\
 \n\
 Release history:\n\
 ---------------\n\
+### 6.1.0 ###\n\
+- Event-B EMF Support for Modelling Extensions Feature (6.1.0)\n\
+- Event-B EMF Support for Modelling Extensions Source Feature (6.1.0): Generated \n\
 ### 6.0.0 ###\n\
 - Event-B EMF Support for Modelling Extensions Feature (6.0.0)\n\
 - Event-B EMF Support for Modelling Extensions Source Feature (6.0.0): Generated \n\
@@ -33,7 +36,7 @@ Release history:\n\
 - Event-B EMF Support for Modelling Extensions Source Feature (5.4.0): Generated \n\
   
 # "copyright" property - copyright of the feature
-featureCopyright=Copyright (c) 2011,2018 University of Southampton. All rights reserved.
+featureCopyright=Copyright (c) 2011-2019 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - name of the update site
 updateSiteName=Main Rodin update site

--- a/ac.soton.eventb.emf.core.extension.sdk/feature.xml
+++ b/ac.soton.eventb.emf.core.extension.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.core.extension.sdk"
       label="%featureName"
-      version="6.1.0.release"
+      version="6.1.0.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.license"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.emf.core.extension.sdk/feature.xml
+++ b/ac.soton.eventb.emf.core.extension.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.core.extension.sdk"
       label="%featureName"
-      version="6.0.0.release"
+      version="6.1.0.release"
       provider-name="%featureVendor"
       license-feature="org.rodinp.license"
       license-feature-version="1.0.0.release">


### PR DESCRIPTION
Facilities to use encoded attribute style for serialised extensions in Rodin as well as separately persisted extensions (contains)